### PR TITLE
Install python3 for new editor tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         xsltproc libxml2-utils libxml2 texlive fonts-inconsolata make nginx \
         curl python python-pip texlive-xetex texlive-fonts-recommended \
-        texlive-fonts-extra lmodern && \
+        texlive-fonts-extra lmodern python3 && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://pilotfiber.dl.sourceforge.net/project/getfo/texml/texml-2.0.2/texml-2.0.2.tar.gz -o texml-2.0.2.tar.gz && \
     tar -xf texml-2.0.2.tar.gz && \


### PR DESCRIPTION
The new editor tooling (to be announced) will need Python 3.

Why is this relevant for docker? We want to run (part of) the tooling during the docker build to generate a XEP metadata list, which can later be used to send emails automatically based on diffs between those lists.